### PR TITLE
Workdir, pre-dir, post-dir basic setup and get string of diff between work-dir and post-dir

### DIFF
--- a/agent_or1.py
+++ b/agent_or1.py
@@ -6,21 +6,25 @@ import sys
 import argparse
 from config import *
 from challenge import get_challenge_by_id, Challenge
-from utils import extract_xml_structures, get_completion
+from utils import *
 
 def start_agent(challenge, model, max_rounds):
     tw = AgentShell(cwd=challenge.workdir)
     messages = get_pre_prompt(challenge)
     for round_i in range(max_rounds):
-        print('Round', round_i)
+        print('ROUND', round_i)
         response_text = get_completion(
             messages, model, OPENROUTER_API_KEY, add_assistant_response=True)
-        print('messages length', len(messages))
-        xml_structures = extract_xml_structures(response_text)
-        print('xml structs', xml_structures)
+        print('ASSISTANT:', response_text)
+        xml_structures = extract_xml_structures2(response_text)
+        print('XML:', xml_structures)
         #assert len(xml_structures) > 0, 'Expected at least one xml structure'
+        if '<done />' in response_text:
+            print('Agent used <done /> tag to signal completion. Exiting.')
+            assert len(xml_structures) == 0, "Expected no xml structures together with <done /> tag, should be implemented."
+            break
         if len(xml_structures) == 0:
-            print('No xml structures found.')
+            print('NO XML CONTINUE')
             messages.append({
                 "role": "user",
                 "content": "ERROR. No stdin or done tag found. Remember that all code to be executed in shell must be in <stdin> tags. If you think you're done with the task, use the <done /> tag."
@@ -29,24 +33,24 @@ def start_agent(challenge, model, max_rounds):
         #assert len(xml_structures) == 1, 'Expected one xml structure'
         stdout_string = ''
         for xml_structure in xml_structures:
-            print('xml struct', xml_structure)
+            #print('xml struct', xml_structure)
             if xml_structure['tag'] == 'done':
                 print('Agent used <done /> tag to signal completion. Exiting.')
                 break
             assert xml_structure['tag'] == 'stdin', 'Expected stdin tag'
             command_input = xml_structure['content']
-            print('command input', command_input)
+            #print('command input', command_input)
             command_id, command_output = tw.round_trip(command_input)
-            print('%', command_id)
-            print('command output', command_output)
+            #print('%', command_id)
+            #print('command output', command_output)
             stdout_string += '<stdout>' + command_output + '</stdout>'
-        print('user will reply:', stdout_string)
+        print('USER:', stdout_string)
         messages.append({
             "role": "user",
             "content": stdout_string
         })
-        print('Appended stdout')
-    print('end of rounds')
+    print('END OF ROUNDS')
+    print('comparing work and postdir:', diff_workdir_postdir_compare(challenge.workdir, challenge.postdir))
 
 # take command line arguments
 if __name__ == "__main__":

--- a/agent_or1.py
+++ b/agent_or1.py
@@ -16,7 +16,7 @@ def start_agent(challenge, model, max_rounds):
         response_text = get_completion(
             messages, model, OPENROUTER_API_KEY, add_assistant_response=True)
         print('ASSISTANT:', response_text)
-        xml_structures = extract_xml_structures2(response_text)
+        xml_structures = extract_xml_structures(response_text)
         print('XML:', xml_structures)
         #assert len(xml_structures) > 0, 'Expected at least one xml structure'
         if '<done />' in response_text:

--- a/challenge.py
+++ b/challenge.py
@@ -1,22 +1,41 @@
 import os
 from config import challenges_dir
+from os.path import exists, join
+import shutil
 
 class Challenge:
-    def __init__(self, challenge_id, challenge_dir, challenge_workdir, task_prompt):
+    def __init__(self, challenge_id, challenge_dir, challenge_workdir, challenge_predir, challenge_postdir, task_prompt):
         self.challenge_id = challenge_id
         self.challenge_dir = challenge_dir
         self.workdir = challenge_workdir
+        self.predir = challenge_predir
+        self.postdir = challenge_postdir
         self.task_prompt = task_prompt
+        print('Challenge created', self.workdir)
         
 def get_challenge_by_id(challenge_id):
-    challenge_dir = os.path.join(challenges_dir, challenge_id)
-    challenge_workdir = os.path.join(challenge_dir, 'workdir')
-    assert os.path.exists(challenge_dir), f'Challenge dir {challenge_dir} does not exist'
-    assert os.path.exists(challenge_workdir), f'Challenge workdir {challenge_workdir} does not exist'
-    task_prompt_txt_file_path = os.path.join(challenge_dir, 'task_prompt.txt')
-    assert os.path.exists(task_prompt_txt_file_path), f'Task prompt file {task_prompt_txt_file_path} does not exist'
+    challenge_dir = join(challenges_dir, challenge_id)
+    dirs_path = join(challenge_dir, 'dirs')
+    assert exists(dirs_path), f'Dirs file {dirs_path} does not exist'
+
+    pre_dir = join(dirs_path, 'pre')
+    post_dir = join(dirs_path, 'post')
+    assert exists(pre_dir), f'Pre dir {pre_dir} does not exist'
+    assert exists(post_dir), f'Post dir {post_dir} does not exist'
+    work_dir = join(dirs_path, 'workdir')
+    # if work_dir exists, delete it and all contents
+    if exists(work_dir):
+        shutil.rmtree(work_dir)
+        assert not exists(work_dir), f'Work dir {work_dir} could not be removed'
+    # create work_dir
+    #os.makedirs(work_dir)
+    # copy pre_dir to work_dir
+    shutil.copytree(pre_dir, work_dir)
+
+    task_prompt_txt_file_path = join(challenge_dir, 'task_prompt.txt')
+    assert exists(task_prompt_txt_file_path), f'Task prompt file {task_prompt_txt_file_path} does not exist'
     task_prompt = open(task_prompt_txt_file_path).read().strip()
     
     # define challenge class
-    challenge = Challenge(challenge_id, challenge_dir, challenge_workdir, task_prompt)
+    challenge = Challenge(challenge_id, challenge_dir, work_dir, pre_dir, post_dir, task_prompt)
     return challenge   

--- a/challenges/001/dirs/post/hey/yo
+++ b/challenges/001/dirs/post/hey/yo
@@ -1,0 +1,1 @@
+hello world

--- a/challenges/001/dirs/workdir/hey/yo
+++ b/challenges/001/dirs/workdir/hey/yo
@@ -1,0 +1,1 @@
+hello world

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,8 @@
 import requests
 import json 
 import re
-
+from os.path import exists, join
+from config import *
 
 def extract_xml_structures(input_string):
     pattern = r'<(\w+)>(.+?)</\1>'
@@ -18,8 +19,23 @@ def extract_xml_structures(input_string):
     
     return result
 
+def extract_xml_structures2(input_string):
+    pattern = r'<(\w+)(?:>(.*?)</\1>|/>)'  # Updated pattern to handle empty tags
+    matches = re.findall(pattern, input_string)
+    
+    result = []
+    for match in matches:
+        tag, content = match
+        element = {
+            'tag': tag,
+            'content': content.strip()
+        }
+        result.append(element)
+    
+    return result
+
 def get_completion(messages, model, or_api_key, add_assistant_response=True):
-    print('get response start', messages)
+    #print('get response start', messages)
     response = requests.post(
     url="https://openrouter.ai/api/v1/chat/completions",
     headers={
@@ -31,14 +47,42 @@ def get_completion(messages, model, or_api_key, add_assistant_response=True):
     })
     )
     data = response.json()
-    print('data', data)
+    #print('data', data)
     assert len(data['choices']) == 1, 'Expected one choice'
     response_text = data['choices'][0]['message']['content']
-    print('res text', response_text)
-    print('get reponse end')
+    #print('res text', response_text)
+    #print('get reponse end')
     if add_assistant_response:
         messages.append({
             "role": "assistant",
             "content": response_text
         })
     return response_text
+
+import filecmp
+
+def workdir_postdir_compare(dir1, dir2):
+    dir1 = join(challenges_dir,'001/dirs/workdir')
+    dir2 = join(challenges_dir,'001/dirs/post')
+
+    dcmp = filecmp.dircmp(dir1, dir2)
+    print("Files only in {}: {}".format(dir1, dcmp.left_only))
+    print("Files only in {}: {}".format(dir2, dcmp.right_only))
+    print("Common files, same content: {}".format(dcmp.common_files))
+    print("Common files but different: {}".format(dcmp.diff_files))
+    print("Common subdirectories: {}".format(dcmp.common_dirs))
+
+def diff_workdir_postdir_compare(dir1, dir2):
+    dir1 = join(challenges_dir,'001/dirs/workdir')
+    dir2 = join(challenges_dir,'001/dirs/post')
+
+    # using subprocess do diff -r dir1 dir2 and get string output
+    import subprocess
+    cmd = f'diff -r {dir1} {dir2}'
+    process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
+    output, error = process.communicate()
+    output_str = output.decode('utf-8')
+    if error is not None:
+        # exception
+        raise Exception(f'Error in diff command: {error}')
+    return output_str

--- a/utils.py
+++ b/utils.py
@@ -5,21 +5,6 @@ from os.path import exists, join
 from config import *
 
 def extract_xml_structures(input_string):
-    pattern = r'<(\w+)>(.+?)</\1>'
-    matches = re.findall(pattern, input_string)
-    
-    result = []
-    for match in matches:
-        tag, content = match
-        element = {
-            'tag': tag,
-            'content': content.strip()
-        }
-        result.append(element)
-    
-    return result
-
-def extract_xml_structures2(input_string):
     pattern = r'<(\w+)(?:>(.*?)</\1>|/>)'  # Updated pattern to handle empty tags
     matches = re.findall(pattern, input_string)
     
@@ -59,23 +44,7 @@ def get_completion(messages, model, or_api_key, add_assistant_response=True):
         })
     return response_text
 
-import filecmp
-
-def workdir_postdir_compare(dir1, dir2):
-    dir1 = join(challenges_dir,'001/dirs/workdir')
-    dir2 = join(challenges_dir,'001/dirs/post')
-
-    dcmp = filecmp.dircmp(dir1, dir2)
-    print("Files only in {}: {}".format(dir1, dcmp.left_only))
-    print("Files only in {}: {}".format(dir2, dcmp.right_only))
-    print("Common files, same content: {}".format(dcmp.common_files))
-    print("Common files but different: {}".format(dcmp.diff_files))
-    print("Common subdirectories: {}".format(dcmp.common_dirs))
-
 def diff_workdir_postdir_compare(dir1, dir2):
-    dir1 = join(challenges_dir,'001/dirs/workdir')
-    dir2 = join(challenges_dir,'001/dirs/post')
-
     # using subprocess do diff -r dir1 dir2 and get string output
     import subprocess
     cmd = f'diff -r {dir1} {dir2}'


### PR DESCRIPTION
In challenge.get_challenge_by_id, challenge directory is checking for existence of 
./dir/pre and ./dir/post

(If ./dir/workdir exists it is deleted) and then pre-dir is copied to work-dir.

In agent_or1.start_agent, after completed attempt, utils.diff_workdir_postdir_compare is used to get a string of the diff betwen workdir and post-dir. This string can then be used for evaluation.