### PR TITLE
added basic redis pubsub for agentshell

### DIFF
--- a/agent1.py
+++ b/agent1.py
@@ -1,6 +1,11 @@
 from agentshells.shell1 import AgentShell
+import redis
+import os
 
-tw = AgentShell(cwd='/home/ec2-user/projects/unixagentbench/challenges/challenge1')
+redis_client = redis.Redis(password=os.environ['REDIS_PASSWORD'])
+tw = AgentShell(cwd='/home/ec2-user/projects/unixagentbench/emptydir',
+                redis_pubsub_channel='myagentshellchannel',
+                redis_client=redis_client)
 try:
     print("Terminal Wrapper: Type your command and press enter. Type 'exit' to quit.")
 


### PR DESCRIPTION
AgentShell now has 2 additional parameters in its constructor

- redis_pubsub_channel: A string that specifies the name of the pubsub channel that commands will be pub'ed to, if None no pub is performed
- redis_client: Default is none, but has to be not none if redis_pubusb_channel is not None. This is the redis client used to do the publishing, which can e.g. include auth info

Pub happens in the round_trip method, where the same dict that is returned is also published. The return dict has been changed to include: command_input and shell_id. The shell_id is is a uuid4 generated at initialization of the the agentshell object.